### PR TITLE
updated initsystem to be future-proof for ubuntu releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ tests/modules/
 
 # Beaker
 log/
+
+.idea/

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/lib/facter/initsystem.rb
+++ b/lib/facter/initsystem.rb
@@ -29,8 +29,9 @@ Facter.add(:initsystem) do
         'sysvinit'
       end
     when 'Ubuntu'
-      case os['release']['major']
-      when '15.04', '15.10', '16.04'
+      version = os['release']['major']
+      major = version.split('.')[0]
+      if major.to_i >= 15
         'systemd'
       else
         'upstart'


### PR DESCRIPTION
I updated the check for Ubuntu versions to be future-proofed.

I noticed that this puppet module did not work at all for Ubuntu 17.04, so I modified the check to just treat every release >= 15.04 the same -- they are all running systemd

Also, I was making these changes within Intellij, so don't worry about the added .idea folder, its just extra noise from the IDE.